### PR TITLE
Application would stop working in case of a reducer error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,10 +13,16 @@ export function batchMiddleware({ dispatch }) {
         case BATCH: {
           dispatch({ type: PUSH });
           const returnArray = [];
-          action.payload.forEach((batchedAction) => {
-            returnArray.push(dispatch(batchedAction));
-          });
-          dispatch({ type: POP });
+          try {
+              action.payload.forEach((batchedAction) => {
+                  returnArray.push(dispatch(batchedAction));
+              });
+          } catch(e) {
+            throw e;
+          } finally {
+              dispatch({ type: POP });
+          }
+
           return returnArray;
         }
         default: {


### PR DESCRIPTION
Current implementation would make the dispatch function stop working in case of a broken reducer within a batch, since the batch counter would never reset properly:

Example:
```js
/*
this would make redux throw an error, which would also freeze `batchDepth` at 1. 
Subsequent dispatches will never reach the listeners.
*/
store.dispatch(["foo"]);
```

Although redux already wraps the reducers in a `try` block, if any other middleware overrides `dispatch` in a way that doesn't produce 100% breakage, or if user has a broken action, application would stop working completely until a refresh. 